### PR TITLE
chore: add Prettier command

### DIFF
--- a/.nvimrc.vim.link
+++ b/.nvimrc.vim.link
@@ -256,6 +256,9 @@ inoremap <silent><expr> <TAB>
 "Close preview window when completion is done.
 autocmd! CompleteDone * if pumvisible() == 0 | pclose | endif
 
+"Prettier command
+command! -nargs=0 Prettier :CocCommand prettier.formatFile
+
 "========Custom Mapping======== 
 inoremap jj <Esc>
 


### PR DESCRIPTION
### Overview

Removing the plugin Prettier in #1 has removed the global command `Prettier` turns out I use that quite often so this PR adds it back
