### PR TITLE
chore: add goyo

### DIFF
--- a/.nvimrc.vim.link
+++ b/.nvimrc.vim.link
@@ -1,12 +1,14 @@
 call plug#begin()
+
 Plug 'Yggdroot/indentLine'
 Plug 'airblade/vim-gitgutter'
+Plug 'arcticicestudio/nord-vim'
 Plug 'christoomey/vim-sort-motion'
 Plug 'christoomey/vim-tmux-navigator'
 Plug 'iamcco/markdown-preview.nvim', { 'do': 'cd app & npm i'  }
-Plug 'arcticicestudio/nord-vim'
 Plug 'junegunn/fzf', { 'do': { -> fzf#install() } }
 Plug 'junegunn/fzf.vim'
+Plug 'junegunn/goyo.vim'
 Plug 'junegunn/vim-peekaboo'
 Plug 'neoclide/coc.nvim', {'branch': 'release'}
 Plug 'schickling/vim-bufonly'


### PR DESCRIPTION
### Overview

This PR adds the Goyo.nvim plugin, with the tagline "Distraction-free writing in Vim" this plugin gives a clean UI to do any kind of non-code writing in vim

### Usage

To turn it on use `:Goyo`
To turn it off use `:Goyo!`

### Shortcut

No shortcut has been added, use the raw command to turn it on or off

### Notes

This description has been written with Goyo on
